### PR TITLE
Added `countdown` as a mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can check [index.js](https://github.com/xgfe/react-native-datepicker/blob/ma
 | :------------ |:---------------:| :---------------:| :-----|
 | style | - | `object` | Specify the style of the DatePicker, eg. width, height...  |
 | date | - | <code>string &#124; date &#124; Moment instance</code> | Specify the display date of DatePicker. `string` type value must match the specified format |
-| mode | 'date' | `enum` | The `enum` of `date`, `datetime` and `time` |
+| mode | 'date' | `enum` | The `enum` of `date`, `datetime`, `time` and `countdown` |
 | androidMode | 'default' | `enum` | The `enum` of `default`, `calendar` and `spinner` (only Android) |
 | format | 'YYYY-MM-DD' | `string` | Specify the display format of the date, which using [moment.js](http://momentjs.com/). The default value change according to the mode. |
 | confirmBtnText | '确定' | `string` | Specify the text of confirm btn in ios. |

--- a/datepicker.js
+++ b/datepicker.js
@@ -468,7 +468,7 @@ DatePicker.defaultProps = {
 }
 
 DatePicker.propTypes = {
-  mode: PropTypes.oneOf(['date', 'datetime', 'time']),
+  mode: PropTypes.oneOf(['date', 'datetime', 'time', 'countdown']),
   androidMode: PropTypes.oneOf(['clock', 'calendar', 'spinner', 'default']),
   date: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date), PropTypes.object]),
   format: PropTypes.string,


### PR DESCRIPTION
React Native's DatePickerIOS component allows for a `countdown` mode. This PR adds `countdown` as a propType option to the `mode` prop.

More info about allowed `mode` values:
https://facebook.github.io/react-native/docs/datepickerios#mode